### PR TITLE
[Config] Using a configuration file instead of class constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,8 @@ vendor/*
 composer.phar
 composer.lock
 
+# Configuration files
+app/config/parameters.yml
+
 # IDE config
 nbproject/*

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # SoulMeMaybe, client NetSoul
 
 > Hey, I just met EPITECH,
+>
 > And this is crazy,
+>
 > But here's my NetSoul client,
+>
 > So soul me, maybe?
 
 NetSoul is a protocol used in EPITECH university allowing its students to:

--- a/app/SoulMeMaybe.php
+++ b/app/SoulMeMaybe.php
@@ -10,7 +10,7 @@ require __DIR__.'/../vendor/autoload.php';
  * @author Loic Chardonnet <loic.chardonnet@gmail.com>
  */
 try {
-    $kernel = new Kernel();
+    $kernel = new Kernel(__DIR__.'/config/parameters.yml');
     $kernel->connect();
 } catch (\Exception $exception) {
     die($exception->getMessage());

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -1,7 +1,12 @@
 parameters:
+    # You MUST edit the following parameters.
     login: 'login'
     password_socks: 'password_socks'
 
-    # You shouldn't have to edit the following ones
+    # You CAN edit the following parameters
+    client: 'SoulMeMaybe 0.0.0'
+    user_location: 'Somewhere'
+
+    # You SHOULDN'T edit the following parameters
     host: '10.42.1.59'
     port: 4242

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -6,6 +6,7 @@ parameters:
     # You CAN edit the following parameters
     client: 'SoulMeMaybe 0.0.0'
     user_location: 'Somewhere'
+    ping_answer: 'Hey, You just pinged me, And this is crazy, But here's my ping answer, So soul me, maybe?'
 
     # You SHOULDN'T edit the following parameters
     host: '10.42.1.59'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -1,0 +1,7 @@
+parameters:
+    login: 'login'
+    password_socks: 'password_socks'
+
+    # You shouldn't have to edit the following ones
+    host: '10.42.1.59'
+    port: 4242

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "symfony/yaml": "2.1.*",
+        "symfony/config": "2.1.*"
     },
     "autoload": {
         "psr-0": { "": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     ],
     "require": {
         "symfony/yaml": "2.1.*",
-        "symfony/config": "2.1.*"
     },
     "autoload": {
         "psr-0": { "": "src/" }

--- a/doc/03-SoulMeMaybe-RFC.md
+++ b/doc/03-SoulMeMaybe-RFC.md
@@ -9,9 +9,9 @@ SoulMeMaybe will connect to the following server:
 * **name**: `10.42.1.59`;
 * **port**: `4242`.
 
-## Connection protocol
+## Protocol
 
-Here is the protocol to follow after connecting to the server:
+Here is the protocol followed by SoulMeMaybe:
 
 1. **server**: `salut <socket number> <hash seed> <client host> <client port> <server timestamp>`;
 2. **client**: `auth_ag ext_user none none`;

--- a/doc/03-SoulMeMaybe-RFC.md
+++ b/doc/03-SoulMeMaybe-RFC.md
@@ -13,9 +13,13 @@ SoulMeMaybe will connect to the following server:
 
 Here is the protocol to follow after connecting to the server:
 
-1. **server**: `salut <socket number> <hash seed> <client host> <client port> <timestamp server>`;
+1. **server**: `salut <socket number> <hash seed> <client host> <client port> <server timestamp>`;
 2. **client**: `auth_ag ext_user none none`;
 3. **server**: `rep 002 -- cmd end`;
-4. **client**: `ext_user_log <user login> <authentication hash> <user data> <user location>`.
+4. **client**: `ext_user_log <login> <authentication hash> <client> <user location>`.
 
-With `<authentication hash>` being `md5("<hash seed>-<client host>/<client port><pass socks>")`.
+With:
+
+* `<authentication hash>` being `md5("<hash seed>-<client host>/<client port><password socks>")`;
+* `<client>` being `<client name> <client version>`;
+* `<user location>` being `<in PIE> <room> <line> <station>`.

--- a/doc/03-SoulMeMaybe-RFC.md
+++ b/doc/03-SoulMeMaybe-RFC.md
@@ -16,7 +16,9 @@ Here is the protocol to follow after connecting to the server:
 1. **server**: `salut <socket number> <hash seed> <client host> <client port> <server timestamp>`;
 2. **client**: `auth_ag ext_user none none`;
 3. **server**: `rep 002 -- cmd end`;
-4. **client**: `ext_user_log <login> <authentication hash> <client> <user location>`.
+4. **client**: `ext_user_log <login> <authentication hash> <client> <user location>`;
+5. **server**: `ping <timeout in seconds>`;
+6. **client**: `<ping answer>`.
 
 With:
 

--- a/src/Gnugat/SoulMeMaybe/Kernel.php
+++ b/src/Gnugat/SoulMeMaybe/Kernel.php
@@ -2,6 +2,8 @@
 
 namespace Gnugat\SoulMeMaybe;
 
+use Symfony\Component\Yaml\Yaml;
+
 /**
  * Kernel class.
  *
@@ -9,8 +11,20 @@ namespace Gnugat\SoulMeMaybe;
  */
 class Kernel
 {
-    const HOST = '10.42.1.59';
-    const PORT = 4242;
+    /**
+     * @var array The parameters.
+     */
+    private $parameters;
+
+    /**
+     * The constructor.
+     *
+     * @param string $parametersFilePath The parameters file path.
+     */
+    public function __construct($parametersFilePath)
+    {
+        $this->parameters = Yaml::parse($parametersFilePath)['parameters'];
+    }
 
     /**
      * Connects to the NetSoul server.
@@ -19,7 +33,7 @@ class Kernel
      */
     public function connect()
     {
-        $filePointer = fsockopen(self::HOST, self::PORT);
+        $filePointer = fsockopen($this->parameters['host'], $this->parameters['port']);
 
         if (false === $filePointer) {
             throw new \Exception("Error: Could not connect to the NetSoul server\n");


### PR DESCRIPTION
Instead of using class constants like `HOST` and `PORT`, use a `parameters.yml` file, allowing the user to customize SoulMeMaybe
