### PR TITLE
Handle managment of signal simpler

### DIFF
--- a/src/Gnugat/SoulMeMaybe/Application.php
+++ b/src/Gnugat/SoulMeMaybe/Application.php
@@ -142,10 +142,7 @@ EOF;
     {
         declare(ticks = 1);
 
-        $cleanExit = function() {
-            exit;
-        };
-        pcntl_signal(SIGINT, $cleanExit);
-        pcntl_signal(SIGTERM, $cleanExit);
+        pcntl_signal(SIGINT, 'exit');
+        pcntl_signal(SIGTERM, 'exit');
     }
 }


### PR DESCRIPTION
1. I did not test it
2. As you don't require ext pcntl in you composer.json you should check if functions are available
3. As you declare `ticks =1` and you exit when signaled, this code is useless.

My 2 cents ;)
